### PR TITLE
Fix permissions in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,9 +8,9 @@ commands:
   itempredicateparser:
     aliases: [ipp]
 permissions:
-  itempredicateparser.command.reload:
+  itempredicateparser.command.ipp.reload:
     description: 'Invoke the reload command'
     default: op
-  itempredicateparser.command.test:
+  itempredicateparser.command.ipp.test:
     description: 'Invoke the test command'
     default: op


### PR DESCRIPTION
After testing, the original permissions node in plugin.yml was not available (even though it could be find by LuckPerms), but debugging with LuckPerms found the correct permissions node